### PR TITLE
Map Zabbix triggers to Rundeck jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # rundeck-zabbix
 Runbook Automation integration with Zabbix and Rundeck based on https://kosyfrances.github.io/rundeck-zabbix/
-Using Zabbix API v4.0 and Rundeck API v27
+Using Zabbix API v4.0 and Rundeck API v30

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib"
+	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
 )
 
 // Use for generating resources
@@ -12,4 +17,16 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
+}
+
+func createZabbixClient() (*zabbix.API, error) {
+	newConfig, err := lib.NewConfigFromFile(lib.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create config from file. %v", err)
+
+	}
+	URL := newConfig.Zabbix.URL
+	key := newConfig.Zabbix.APIKey
+
+	return zabbix.CreateClientUsingAPIKey(URL, key)
 }

--- a/cli/cmd/jobs.go
+++ b/cli/cmd/jobs.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib/jobs"
+)
+
+var prefix string
+var jobsFilePath string
+
+// jobsCmd represents the jobs command
+var jobsCmd = &cobra.Command{
+	Use:   "jobs",
+	Short: "generate Rundeck jobs",
+	Long: `generate Rundeck jobs document in Yaml format with triggers information about hosts from Zabbix
+
+	If a prefix is given, jobs will be generated from triggers with the given prefix.
+	Otherwise, jobs will be generated from all the triggers in Zabbix.
+
+	If a file is given, the generated jobs are appended to the file.
+	If the given file path does not exist, it gets created.
+	Otherwise, a jobs.yml file is generated in the current path.`,
+	Run: runJobs,
+}
+
+func init() {
+	generateCmd.AddCommand(jobsCmd)
+	jobsCmd.Flags().StringVar(&jobsFilePath, "file", "jobs.yml", "Path to file where generated Jobs will be written.")
+	jobsCmd.Flags().StringVar(&prefix, "prefix", "", "Generate triggers from the given prefix, otherwise, jobs will be generated from all the triggers in Zabbix.")
+}
+
+func runJobs(cmd *cobra.Command, args []string) {
+	a, err := createZabbixClient()
+	if err != nil {
+		log.Errorf("error creating Zabbix client. %v", err)
+		return
+	}
+
+	res, err := a.GetTriggersInfo()
+	if err != nil {
+		log.Errorf("cannot get triggers info. %v", err)
+		return
+	}
+
+	// No active triggers are on Zabbix
+	if len(res) == 0 {
+		log.Warn("No active triggers found.")
+		return
+	}
+
+	if err = jobs.Make(res, jobsFilePath, prefix); err != nil {
+		log.Errorf("cannot generate jobs. %v", err)
+	} else {
+		log.Infof("Jobs generated in %v", jobsFilePath)
+	}
+}

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kosyfrances/rundeck-zabbix/lib/resources"
 )
 
+var resourceFilePath string
+
 // resourceCmd represents the resource command
 var resourcesCmd = &cobra.Command{
 	Use:   "resources",
@@ -21,7 +23,7 @@ var resourcesCmd = &cobra.Command{
 
 func init() {
 	generateCmd.AddCommand(resourcesCmd)
-	resourcesCmd.Flags().StringVar(&filePath, "file", "resources.yml", "Path to file where generated Resources will be written")
+	resourcesCmd.Flags().StringVar(&resourceFilePath, "file", "resources.yml", "Path to file where generated Resources will be written")
 }
 
 func runResources(cmd *cobra.Command, args []string) {
@@ -43,9 +45,9 @@ func runResources(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err = resources.Make(res, filePath); err != nil {
+	if err = resources.Make(res, resourceFilePath); err != nil {
 		log.Errorf("cannot generate resource. %v", err)
 	} else {
-		log.Infof("Resources generated in %v", filePath)
+		log.Infof("Resources generated in %v", resourceFilePath)
 	}
 }

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -4,12 +4,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/kosyfrances/rundeck-zabbix/lib"
 	"github.com/kosyfrances/rundeck-zabbix/lib/resources"
-	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
 )
-
-var filePath string
 
 // resourceCmd represents the resource command
 var resourcesCmd = &cobra.Command{
@@ -29,17 +25,9 @@ func init() {
 }
 
 func runResources(cmd *cobra.Command, args []string) {
-	newConfig, err := lib.NewConfigFromFile(lib.ConfigPath)
+	a, err := createZabbixClient()
 	if err != nil {
-		log.Errorf("cannot create config from file. %v", err)
-		return
-	}
-	URL := newConfig.Zabbix.URL
-	key := newConfig.Zabbix.APIKey
-
-	a, err := zabbix.CreateClientUsingAPIKey(URL, key)
-	if err != nil {
-		log.Errorf("cannot find needed params. %v", err)
+		log.Errorf("error creating Zabbix client. %v", err)
 		return
 	}
 

--- a/lib/jobs/job.go
+++ b/lib/jobs/job.go
@@ -1,0 +1,77 @@
+package jobs
+
+import (
+	"fmt"
+	"strings"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib/utils"
+	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
+)
+
+type nodeFilters struct {
+	Filter string `yaml:"filter"`
+}
+
+type commands struct {
+	Exec string `yaml:"exec"`
+}
+
+type sequence struct {
+	Commands []commands `yaml:"commands"`
+}
+
+type job struct {
+	Name        string      `yaml:"name"`
+	Description string      `yaml:"description"`
+	NodeFilters nodeFilters `yaml:"nodefilters"`
+	Sequence    sequence    `yaml:"sequence"`
+}
+
+/*
+Make generates Rundeck job model document in Yaml format
+with triggers' information from Zabbix
+
+The file output similar to:
+
+- name: test-job
+  description: Just a random test
+  nodefilters:
+    filter: 'dummy-host'
+  sequence:
+    commands:
+    - exec: ""
+*/
+func Make(results zabbix.TriggerResults, filePath, prefix string) error {
+
+	var jobList []job
+
+	for _, result := range results {
+		if strings.HasPrefix(result.Description, prefix) {
+			for _, host := range result.Hosts {
+				resultFilter := nodeFilters{
+					Filter: host.Name,
+				}
+
+				seq := sequence{
+					Commands: []commands{{Exec: ""}},
+				}
+
+				j := job{
+					Name:        result.Description,
+					Description: result.Description,
+					NodeFilters: resultFilter,
+					Sequence:    seq,
+				}
+				jobList = append(jobList, j)
+			}
+		}
+	}
+
+	d, err := yaml.Marshal(&jobList)
+	if err != nil {
+		return fmt.Errorf("cannot marshal resource to yaml. %v", err)
+	}
+	return utils.DumpToFile(filePath, d)
+}

--- a/lib/jobs/job_test.go
+++ b/lib/jobs/job_test.go
@@ -1,0 +1,135 @@
+package jobs
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
+)
+
+// Test that we can get Rundeck job model document in Yaml format
+// with triggers' information from Zabbix
+func TestMakeJob(t *testing.T) {
+	expected := zabbix.TriggerResults{
+		{
+			Description: "random trigger on dummy-host",
+			Hosts: []zabbix.TriggerHost{
+				{Name: "dummy-host"},
+			},
+		}, {
+			Description: "prefix random trigger on dummy-host2",
+			Hosts: []zabbix.TriggerHost{
+				{Name: "dummy-host2"},
+			},
+		},
+	}
+
+	// mock api call
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		res := struct {
+			zabbix.TriggerResults `json:"result"`
+		}{expected}
+		err := json.NewEncoder(w).Encode(res)
+		if err != nil {
+			t.Fatalf("unable to write response. error: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	// generate temp file
+	tmpfile, err := ioutil.TempFile("", "testfile.*.yml")
+	if err != nil {
+		t.Fatalf("unable to create temporary file. error: %v", err)
+	}
+
+	defer os.Remove(tmpfile.Name()) // clean up
+	defer tmpfile.Close()           // close file
+
+	a, err := zabbix.CreateClientUsingAPIKey(ts.URL, "fake_zabbix_key")
+	if err != nil {
+		t.Fatalf("process ran with err %v", err)
+	}
+
+	res, err := a.GetTriggersInfo()
+	if err != nil {
+		t.Fatalf("cannot get triggers info.\n%v", err)
+	}
+
+	// Without prefix for triggers
+	err = Make(res, tmpfile.Name(), "")
+	if err != nil {
+		t.Fatalf("expected job model document to be generated. error: %v", err)
+	}
+
+	// check the file's content
+	e := `
+- name: random trigger on dummy-host
+  description: random trigger on dummy-host
+  nodefilters:
+    filter: dummy-host
+  sequence:
+    commands:
+    - exec: ""
+- name: prefix random trigger on dummy-host2
+  description: prefix random trigger on dummy-host2
+  nodefilters:
+    filter: dummy-host2
+  sequence:
+    commands:
+    - exec: ""`
+
+	c, err := ioutil.ReadFile(tmpfile.Name())
+
+	if err != nil {
+		t.Fatalf("expected file content to be %v\n error: %v", e, err)
+	}
+
+	content := strings.Trim(string(c), "\n")
+	expectedContent := strings.Trim(e, "\n")
+
+	if content != expectedContent {
+		t.Fatalf("test returned \n%v\n\n expected file content to be \n%v", content, expectedContent)
+	}
+
+	// Truncate temp file (We want previous file contents gone before next test)
+	err = tmpfile.Truncate(0)
+	if err != nil {
+		t.Fatalf("expected file to be truncated. error: %v", err)
+	}
+
+	// With prefix for triggers
+	err = Make(res, tmpfile.Name(), "prefix")
+	if err != nil {
+		t.Fatalf("expected job model document to be generated. error: %v", err)
+	}
+
+	// check the file's content
+	e = `
+- name: prefix random trigger on dummy-host2
+  description: prefix random trigger on dummy-host2
+  nodefilters:
+    filter: dummy-host2
+  sequence:
+    commands:
+    - exec: ""`
+
+	c, err = ioutil.ReadFile(tmpfile.Name())
+
+	if err != nil {
+		t.Fatalf("expected file content to be %v\n error: %v", e, err)
+	}
+
+	content = strings.Trim(string(c), "\n")
+	expectedContent = strings.Trim(e, "\n")
+
+	if content != expectedContent {
+		t.Fatalf("test returned \n%v\n\n expected file content to be \n%v", content, expectedContent)
+	}
+
+}

--- a/lib/resources/resource.go
+++ b/lib/resources/resource.go
@@ -2,15 +2,15 @@ package resources
 
 import (
 	"fmt"
-	"os"
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/kosyfrances/rundeck-zabbix/lib/utils"
 	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
 )
 
 // Resource struct holds Rundeck resource document mapping info
-type Resource struct {
+type resource struct {
 	Name        string `yaml:"hostname"`
 	Node        string `yaml:"nodename"`
 	Description string `yaml:"description"`
@@ -41,11 +41,11 @@ dummy-host:
   username: ""
   ssh-keypath: ""
 */
-func Make(results zabbix.Results, file string) error {
-	m := make(map[string]Resource)
+func Make(results zabbix.HostResults, file string) error {
+	m := make(map[string]resource)
 
 	for _, result := range results {
-		m[result.Name] = Resource{
+		m[result.Name] = resource{
 			Name:        result.Host,
 			Node:        result.Name,
 			Description: result.Description,
@@ -56,21 +56,5 @@ func Make(results zabbix.Results, file string) error {
 	if err != nil {
 		return fmt.Errorf("cannot marshal resource to yaml. %v", err)
 	}
-	return dumpToFile(file, d)
-}
-
-func dumpToFile(filePath string, data []byte) error {
-	// If the filePath doesn't exist, create it, or append to the file
-	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("cannot open file. %v", err)
-	}
-
-	defer f.Close()
-
-	if _, err := f.Write(data); err != nil {
-		return fmt.Errorf("cannot write to file. %v", err)
-	}
-
-	return nil
+	return utils.DumpToFile(file, d)
 }

--- a/lib/resources/resource_test.go
+++ b/lib/resources/resource_test.go
@@ -15,8 +15,7 @@ import (
 // Test that we can get Rundeck resource model document in Yaml format
 // with hosts' information from Zabbix
 func TestMakeResource(t *testing.T) {
-	// mock api call
-	expected := zabbix.Results{
+	expected := zabbix.HostResults{
 		{
 			HostID:      "10261",
 			Host:        "dummy-host",
@@ -24,10 +23,12 @@ func TestMakeResource(t *testing.T) {
 			Description: "",
 		},
 	}
+
+	// mock api call
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		res := struct {
-			zabbix.Results `json:"result"`
+			zabbix.HostResults `json:"result"`
 		}{expected}
 		err := json.NewEncoder(w).Encode(res)
 		if err != nil {
@@ -77,7 +78,7 @@ dummy-host:
 	c, err := ioutil.ReadFile(tmpfile.Name())
 
 	if err != nil {
-		t.Fatalf("expected file content to be %v\n error: %v", e, err)
+		t.Fatalf("expected file content to be %v\n\n error: %v", e, err)
 	}
 
 	content := strings.Trim(string(c), "\n")

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 )
 
 // MakeRequest makes an API request.
@@ -25,4 +26,20 @@ func MakeRequest(method, URL string, payload interface{}) (*http.Response, error
 	req.Header.Set("Content-type", "application/json")
 	// Send the request via a client
 	return http.DefaultClient.Do(req)
+}
+
+// DumpToFile dumps data, a list of bytes to file given.
+// If the filePath doesn't exist, it creates it, or appends to the file
+func DumpToFile(filePath string, data []byte) error {
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("cannot open file. %v", err)
+	}
+
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("cannot write to file. %v", err)
+	}
+	return nil
 }

--- a/lib/zabbix/zabbix_test.go
+++ b/lib/zabbix/zabbix_test.go
@@ -35,7 +35,7 @@ func TestGetKey(t *testing.T) {
 
 // Tests that we can get Resource info from a Zabbix API call
 func TestGetHostsInfo(t *testing.T) {
-	expected := Results{
+	expected := HostResults{
 		{
 			HostID:      "10261",
 			Host:        "dummy-host",
@@ -47,7 +47,7 @@ func TestGetHostsInfo(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		res := struct {
-			Results `json:"result"`
+			HostResults `json:"result"`
 		}{expected}
 		err := json.NewEncoder(w).Encode(res)
 		if err != nil {
@@ -68,5 +68,108 @@ func TestGetHostsInfo(t *testing.T) {
 
 	if !(reflect.DeepEqual(res, expected)) {
 		t.Errorf("expected result to be %v but got %v", expected, res)
+	}
+}
+
+func TestGetTriggersInfo(t *testing.T) {
+	expected := TriggerResults{
+		{
+			Description: "Random trigger description",
+			Hosts: []TriggerHost{
+				TriggerHost{
+					Name: "dummy-host",
+				},
+			},
+		},
+	}
+
+	// mock api call
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		res := struct {
+			TriggerResults `json:"result"`
+		}{expected}
+		err := json.NewEncoder(w).Encode(res)
+		if err != nil {
+			t.Fatalf("unable to write response. error: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	a, err := CreateClientUsingAPIKey(ts.URL, "fake_zabbix_key")
+	if err != nil {
+		t.Fatalf("process ran with err %v,", err)
+	}
+
+	res, err := a.GetTriggersInfo()
+	if err != nil {
+		t.Fatalf("process ran with err %v, want result to be %v", err, expected)
+	}
+
+	if !(reflect.DeepEqual(res, expected)) {
+		t.Errorf("expected result to be %v but got %v", expected, res)
+	}
+}
+
+func TestCreateClientUsingAPIKey(t *testing.T) {
+	expected := &API{
+		URL: "fake_url",
+		Key: "fake_key",
+	}
+
+	// Ensure that client is not created without value for key
+	_, err := CreateClientUsingAPIKey(expected.URL, "")
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+
+	// Ensure that client is not created without value for URL
+	_, err = CreateClientUsingAPIKey("", expected.Key)
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+
+	// Ensure that client is not created without value for URL and key
+	_, err = CreateClientUsingAPIKey("", "")
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+
+	// Ensure that client is can be created with value and key
+	a, err := CreateClientUsingAPIKey(expected.URL, expected.Key)
+	if err != nil {
+		t.Errorf("expected client to be %v but got %v", expected, a)
+	}
+}
+
+func TestCreateClientUsingAuth(t *testing.T) {
+	expected := &API{
+		URL:      "fake_url",
+		User:     "fake_user",
+		Password: "fake_password",
+	}
+
+	// Ensure that client is not created without value for URL
+	_, err := CreateClientUsingAuth("", expected.User, expected.Password)
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+
+	// Ensure that client is not created without value for Username
+	_, err = CreateClientUsingAuth(expected.URL, "", expected.Password)
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+
+	// Ensure that client is not created without value for Password
+	_, err = CreateClientUsingAuth(expected.URL, expected.User, "")
+	if err == nil {
+		t.Error("expected an error but got nil")
+	}
+
+	// Ensure that client is created with required values
+	a, err := CreateClientUsingAuth(expected.URL, expected.User, expected.Password)
+	if err != nil {
+		t.Errorf("expected client to be %v but got %v", expected, a)
 	}
 }


### PR DESCRIPTION
This PR does the following:

- A little bit of code cleanup on resources
- Tests
- Add command to generate jobs document in Yaml format with hosts' triggers' information from Zabbix. 
- If a prefix is given, jobs will be generated from triggers with the given prefix, otherwise, jobs will be generated from all the triggers in Zabbix.
- If a file is given, the generated jobs are appended to the file.
- If the given file path does not exist, it gets created, otherwise, a jobs.yml file is generated in the current path.
```
generate jobs --file ../jobs.yml
generate jobs --file ../jobs.yml --prefix "prefix"
```
Fixes #31 