### PR TITLE
Middleware command to execute job

### DIFF
--- a/cli/cmd/jobs.go
+++ b/cli/cmd/jobs.go
@@ -10,7 +10,7 @@ import (
 var prefix string
 var jobsFilePath string
 
-// jobsCmd represents the jobs command
+// jobsCmd represents the jobs command for generating Rundeck jobs
 var jobsCmd = &cobra.Command{
 	Use:   "jobs",
 	Short: "generate Rundeck jobs",
@@ -21,8 +21,10 @@ var jobsCmd = &cobra.Command{
 
 	If a file is given, the generated jobs are appended to the file.
 	If the given file path does not exist, it gets created.
-	Otherwise, a jobs.yml file is generated in the current path.`,
-	Run: runJobs,
+	Otherwise, a jobs.yml file is generated in the current path.
+	Note that Rundeck job names must not contain slashes.
+	This means that the Trigger name from Zabbix must not also contain slashes.`,
+	Run: generateJobs,
 }
 
 func init() {
@@ -31,7 +33,7 @@ func init() {
 	jobsCmd.Flags().StringVar(&prefix, "prefix", "", "Generate triggers from the given prefix, otherwise, jobs will be generated from all the triggers in Zabbix.")
 }
 
-func runJobs(cmd *cobra.Command, args []string) {
+func generateJobs(cmd *cobra.Command, args []string) {
 	a, err := createZabbixClient()
 	if err != nil {
 		log.Errorf("error creating Zabbix client. %v", err)

--- a/cli/cmd/resources.go
+++ b/cli/cmd/resources.go
@@ -18,7 +18,7 @@ var resourcesCmd = &cobra.Command{
 	If a file path is given, the generated resources are appended to the file.
 	If the given file Path does not exist, it gets created.
 	Otherwise, a resources.yml file is generated in the current path.`,
-	Run: runResources,
+	Run: generateResources,
 }
 
 func init() {
@@ -26,7 +26,7 @@ func init() {
 	resourcesCmd.Flags().StringVar(&resourceFilePath, "file", "resources.yml", "Path to file where generated Resources will be written")
 }
 
-func runResources(cmd *cobra.Command, args []string) {
+func generateResources(cmd *cobra.Command, args []string) {
 	a, err := createZabbixClient()
 	if err != nil {
 		log.Errorf("error creating Zabbix client. %v", err)

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib"
+	"github.com/kosyfrances/rundeck-zabbix/lib/middleware"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var rundeckProject string
+var zabbixTrigger string
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run commands",
+}
+
+// jobCmd represents the job command for executing a Rundeck job from Zabbix server
+var jobCmd = &cobra.Command{
+	Use:   "job",
+	Short: "run/execute a job in a Rundeck project",
+	Long: `run/execute a job in a Rundeck project,
+	given a Zabbix trigger name that matches the Rundeck job name to be executed.
+	This is with the assumption that the job name (i.e Trigger name) being given is unique per project,
+	else it will execute the first match on the list.
+	Note that Rundeck job names must not contain slashes.
+	This means that the Trigger name from Zabbix must not also contain slashes.
+	`,
+	Run: runJob,
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+	runCmd.AddCommand(jobCmd)
+	jobCmd.Flags().StringVar(&rundeckProject, "project", "", "Name of Rundeck project whose job will be executed.")
+	jobCmd.Flags().StringVar(&zabbixTrigger, "trigger", "", "Name of Zabbix trigger that is an exact match of a Rundeck job name to be executed.")
+}
+
+func runJob(cmd *cobra.Command, args []string) {
+	// Get Rundeck Auth Token
+	newConfig, err := lib.NewConfigFromFile(lib.ConfigPath)
+	if err != nil {
+		log.Errorf("cannot create config from file. %v", err)
+		return
+	}
+	authToken := newConfig.Rundeck.APIKey
+	URL := newConfig.Rundeck.URL
+
+	// Get job
+	jobFilter := url.QueryEscape(zabbixTrigger)
+	jobGetEndpoint := fmt.Sprintf("api/17/project/%s/jobs?authtoken=%s&jobExactFilter=%s", rundeckProject, authToken, jobFilter)
+	URLEndpoint, err := middleware.BuildRundeckURLEndpoint(URL, jobGetEndpoint)
+	if err != nil {
+		log.Errorf("cannot build Rundeck URL job get endpoint. %v", err)
+		return
+	}
+
+	ID, err := middleware.GetRundeckJobID(URLEndpoint)
+	if err != nil {
+		log.Errorf("cannot get Rundeck job ID. %v", err)
+		return
+	}
+
+	// Run job
+	jobRunEndpoint := fmt.Sprintf("/api/18/job/%s/run?authtoken=%s", ID, authToken)
+	URLEndpoint, err = middleware.BuildRundeckURLEndpoint(URL, jobRunEndpoint)
+	if err != nil {
+		log.Errorf("cannot build Rundeck URL job run endpoint. %v", err)
+		return
+	}
+
+	err = middleware.ExecuteRundeckJob(URLEndpoint)
+	if err != nil {
+		log.Errorf("cannot execute Rundeck job. Job ID: %s; Error: %v", ID, err)
+	} else {
+		log.Infof("Successfully executed Rundeck job. Job ID: %s", ID)
+	}
+}

--- a/lib/jobs/job.go
+++ b/lib/jobs/job.go
@@ -58,6 +58,11 @@ func Make(results zabbix.TriggerResults, filePath, prefix string) error {
 					Commands: []commands{{Exec: ""}},
 				}
 
+				// Note: Rundeck job names does not accept slashes
+				// https://rundeck.lighthouseapp.com/projects/59277/tickets/558
+				// The user is responsible for ensuring that the trigger description on Zabbix does not contain slashes,
+				// else even if it gets added to the job file, the user will not be able to load it in Rundeck.
+
 				j := job{
 					Name:        result.Description,
 					Description: result.Description,

--- a/lib/middleware/job.go
+++ b/lib/middleware/job.go
@@ -1,0 +1,75 @@
+package middleware
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib/utils"
+)
+
+// BuildRundeckURLEndpoint builds a URL endpoint given a baseURL and an endpoint.
+// It returns the full URL endpoint and an error if any.
+func BuildRundeckURLEndpoint(baseURL, endpoint string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse Rundeck base URL")
+	}
+
+	queryEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse Rundeck query Endpoint")
+	}
+
+	return base.ResolveReference(queryEndpoint).String(), nil
+}
+
+/*
+GetRundeckJobID gets the job ID from Rundeck API.
+
+Note:
+Rundeck API does not return Host/Node name alongside when you try to get a job.
+Here is a scenario:
+A trigger event happens on Zabbix, we collect the Trigger name and Host name,
+make an API call to Rundeck and try to get the corresponding job name on Rundeck.
+Rundeck returns list of jobs with that exact name
+(assuming there are multiple jobs with same name for different servers).
+How do we figure out what exact job to run in this case?
+This function is implemented with the assumption that the job name (i.e Trigger name)
+being given is unique per project, else it will return the first match on the list.
+*/
+func GetRundeckJobID(URL string) (string, error) {
+	type response struct {
+		ID string `json:"id"`
+	}
+
+	var r []response
+
+	resp, err := utils.MakeRundeckRequest(http.MethodGet, URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("cannot make Rundeck API call to get job ID. Error: %v", err)
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&r)
+	if err != nil {
+		return "", fmt.Errorf("cannot decode response. Error: %v", err)
+	}
+
+	if len(r) == 0 {
+		return "", fmt.Errorf("no matching jobs found")
+	}
+
+	return r[0].ID, nil
+}
+
+// ExecuteRundeckJob executes a job on Rundeck given a URL endpoint.
+// It returns an error if any.
+func ExecuteRundeckJob(URL string) error {
+	_, err := utils.MakeRundeckRequest(http.MethodPost, URL, nil)
+	if err != nil {
+		return fmt.Errorf("cannot make Rundeck API call to execute job. Error: %v", err)
+	}
+
+	return nil
+}

--- a/lib/middleware/job_test.go
+++ b/lib/middleware/job_test.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildRundeckURLEndpoint(t *testing.T) {
+	baseURL := "http://rundeckbaseurl:4440"
+	endpoint := "/api/18/job"
+	fullURL := "http://rundeckbaseurl:4440/api/18/job"
+
+	URL, err := BuildRundeckURLEndpoint(baseURL, endpoint)
+	if err != nil {
+		t.Fatalf("Process ran with err %v, want URL to be %s", err, fullURL)
+	}
+
+	if URL != fullURL {
+		t.Errorf("Expected key to be %s", fullURL)
+	}
+}
+
+func TestGetRundeckJobID(t *testing.T) {
+	// mock api call
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{"id":"fake-job-id"}]`)
+	}))
+	defer ts.Close()
+
+	ID, err := GetRundeckJobID(ts.URL)
+	if err != nil {
+		t.Fatalf("Process ran with err %v, want ID to be fake-job-id", err)
+	}
+
+	if ID != "fake-job-id" {
+		t.Error("Expected ID to be fake-job-id")
+	}
+}
+
+func TestExecuteRundeckJob(t *testing.T) {
+	// mock api call
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+	}))
+	defer ts.Close()
+
+	err := ExecuteRundeckJob(ts.URL)
+	if err != nil {
+		t.Fatalf("Process ran with err %v", err)
+	}
+}

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -8,22 +8,44 @@ import (
 	"os"
 )
 
-// MakeRequest makes an API request.
-// It returns a response object and an error object.
-func MakeRequest(method, URL string, payload interface{}) (*http.Response, error) {
-	// Build the request
+func buildRequest(method, URL string, payload interface{}) (*http.Request, error) {
 	b, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("cannot marshal payload. error: %v", err)
 	}
 
 	body := bytes.NewReader(b)
-	req, err := http.NewRequest(method, URL, body)
+	return http.NewRequest(method, URL, body)
+}
+
+// MakeRundeckRequest makes an API request.
+// It sets the header "Accept" as "application/json".
+// It returns a response object and an error object.
+func MakeRundeckRequest(method, URL string, payload interface{}) (*http.Response, error) {
+	// Build the request
+	req, err := buildRequest(method, URL, payload)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create HTTP request. error: %v", err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	// Send the request via a client
+	return http.DefaultClient.Do(req)
+}
+
+// MakeZabbixRequest makes an API request.
+// It sets the header "Content-type" as "application/json".
+// It returns a response object and an error object.
+func MakeZabbixRequest(method, URL string, payload interface{}) (*http.Response, error) {
+	// Build the request
+	req, err := buildRequest(method, URL, payload)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create HTTP request. error: %v", err)
 	}
 
 	req.Header.Set("Content-type", "application/json")
+
 	// Send the request via a client
 	return http.DefaultClient.Do(req)
 }

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -14,20 +14,40 @@ func TestMakeRequest(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// Get request
-	resp, err := MakeRequest(http.MethodPost, ts.URL, nil)
+	// Get Rundeck request
+	resp, err := MakeRundeckRequest(http.MethodGet, ts.URL, nil)
 	if err != nil {
-		t.Fatalf("Process ran with err %v, want response", err)
+		t.Fatalf("MakeRundeckRequest with Get method ran with err %v, want response", err)
 		return
 	}
 	if resp.StatusCode != 200 {
 		t.Error("Expected response status code to be 200")
 	}
 
-	// Post request
-	resp, err = MakeRequest(http.MethodPost, ts.URL, nil)
+	// Get Zabbix request
+	resp, err = MakeZabbixRequest(http.MethodGet, ts.URL, nil)
 	if err != nil {
-		t.Fatalf("Process ran with err %v, want response", err)
+		t.Fatalf("MakeZabbixRequest with Get method ran with err %v, want response", err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Error("Expected response status code to be 200")
+	}
+
+	// Post Rundeck request
+	resp, err = MakeRundeckRequest(http.MethodPost, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("MakeRundeckRequest with Post method ran with err %v, want response", err)
+		return
+	}
+	if resp.StatusCode != 200 {
+		t.Error("Expected response status code to be 200")
+	}
+
+	// Post Zabbix request
+	resp, err = MakeZabbixRequest(http.MethodPost, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("MakeZabbixRequest Post method ran with err %v, want response", err)
 		return
 	}
 	if resp.StatusCode != 200 {

--- a/lib/zabbix/zabbix.go
+++ b/lib/zabbix/zabbix.go
@@ -118,7 +118,7 @@ func (a *API) GetKey() (string, error) {
 		Err *apiError `json:"error"`
 	}
 
-	resp, err := utils.MakeRequest(http.MethodGet, a.URL, payload)
+	resp, err := utils.MakeZabbixRequest(http.MethodGet, a.URL, payload)
 
 	if err != nil {
 		return "", fmt.Errorf("cannot make Zabbix API call. Error: %v", err)
@@ -146,7 +146,7 @@ func (a *API) GetHostsInfo() (HostResults, error) {
 
 	payload := a.BuildPayload(params, "host.get")
 
-	resp, err := utils.MakeRequest(http.MethodGet, a.URL, payload)
+	resp, err := utils.MakeZabbixRequest(http.MethodGet, a.URL, payload)
 	if err != nil {
 		return nil, fmt.Errorf("cannot make API request. error: %v", err)
 	}
@@ -181,7 +181,7 @@ func (a *API) GetTriggersInfo() (TriggerResults, error) {
 
 	payload := a.BuildPayload(params, "trigger.get")
 
-	resp, err := utils.MakeRequest(http.MethodGet, a.URL, payload)
+	resp, err := utils.MakeZabbixRequest(http.MethodGet, a.URL, payload)
 
 	if err != nil {
 		return nil, fmt.Errorf("cannot make API request. error: %v", err)


### PR DESCRIPTION
Fixes #7 

This PR adds middleware command to execute job on Rundeck.
Sample command is 
```
run middleware --project=zabideck --trigger="[RD] etc passwd has been changed on {HOST.NAME}" `
```

Ideally, this command will be run by Zabbix as a [remote command](https://www.zabbix.com/documentation/4.2/manual/config/notifications/action/operation/remote_command). With remote commands you can define that a certain pre-defined command is automatically executed on the monitored host upon some condition. 

This PR also fixes some comments and renames functions in jobs and resources cli.

All tests pass when running `make test`

Update: Command has been changed to 
```
run job --project=zabideck --trigger="[RD] etc passwd has been changed on {HOST.NAME}" `
```