### PR TITLE
Acknowledge event on Zabbix

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -1,12 +1,7 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
-
-	"github.com/kosyfrances/rundeck-zabbix/lib"
-	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
 )
 
 // Use for generating resources
@@ -17,16 +12,4 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
-}
-
-func createZabbixClient() (*zabbix.API, error) {
-	newConfig, err := lib.NewConfigFromFile(lib.ConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create config from file. %v", err)
-
-	}
-	URL := newConfig.Zabbix.URL
-	key := newConfig.Zabbix.APIKey
-
-	return zabbix.CreateClientUsingAPIKey(URL, key)
 }

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kosyfrances/rundeck-zabbix/lib"
+	"github.com/kosyfrances/rundeck-zabbix/lib/zabbix"
+)
+
+func createZabbixClient() (*zabbix.API, error) {
+	newConfig, err := lib.NewConfigFromFile(lib.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create config from file. %v", err)
+
+	}
+	URL := newConfig.Zabbix.URL
+	key := newConfig.Zabbix.APIKey
+
+	return zabbix.CreateClientUsingAPIKey(URL, key)
+}

--- a/lib/jobs/job_test.go
+++ b/lib/jobs/job_test.go
@@ -94,7 +94,7 @@ func TestMakeJob(t *testing.T) {
 	expectedContent := strings.Trim(e, "\n")
 
 	if content != expectedContent {
-		t.Fatalf("test returned \n%v\n\n expected file content to be \n%v", content, expectedContent)
+		t.Errorf("test returned \n%v\n\n expected file content to be \n%v", content, expectedContent)
 	}
 
 	// Truncate temp file (We want previous file contents gone before next test)
@@ -129,7 +129,7 @@ func TestMakeJob(t *testing.T) {
 	expectedContent = strings.Trim(e, "\n")
 
 	if content != expectedContent {
-		t.Fatalf("test returned \n%v\n\n expected file content to be \n%v", content, expectedContent)
+		t.Errorf("test returned \n%v\n\n expected file content to be \n%v", content, expectedContent)
 	}
 
 }

--- a/lib/middleware/job.go
+++ b/lib/middleware/job.go
@@ -35,7 +35,14 @@ A trigger event happens on Zabbix, we collect the Trigger name and Host name,
 make an API call to Rundeck and try to get the corresponding job name on Rundeck.
 Rundeck returns list of jobs with that exact name
 (assuming there are multiple jobs with same name for different servers).
+
+A sample response is:
+[{"id":"91c755ac-dab2-475c-b903-92e5ff59e740","name":"[RD] etc passwd has been changed on {HOST.NAME}","group":null,"project":"zabideck","description":"[RD] /etc/passwd has been changed on {HOST.NAME}","href":"http://localhost:4440/api/27/job/91c755ac-dab2-475c-b903-92e5ff59e740","permalink":"http://localhost:4440/project/zabideck/job/show/91c755ac-dab2-475c-b903-92e5ff59e740","scheduled":false,"scheduleEnabled":true,"enabled":true},
+{"id":"826e88dc-926b-415f-a724-a3a847aae3f2","name":"[RD] etc passwd has been changed on {HOST.NAME}","group":null,"project":"zabideck","description":"[RD] /etc/passwd has bee
+n changed on {HOST.NAME}","href":"http://localhost:4440/api/27/job/826e88dc-926b-415f-a724-a3a847aae3f2","permalink":"http://localhost:4440/project/zabideck/job/show/826e88dc-926b-415f-a724-a3a847aae3f2","scheduled":false,"scheduleEnabled":true,"enabled":true}]
+
 How do we figure out what exact job to run in this case?
+
 This function is implemented with the assumption that the job name (i.e Trigger name)
 being given is unique per project, else it will return the first match on the list.
 */
@@ -63,13 +70,33 @@ func GetRundeckJobID(URL string) (string, error) {
 	return r[0].ID, nil
 }
 
+type job struct {
+	Name string `json:"name"`
+}
+
+// JobExecResponse struct to hold result from Rundeck job execution
+type JobExecResponse struct {
+	ID      int    `json:"id"`
+	Status  string `json:"status"`
+	Project string `json:"project"`
+	Job     job    `json:"job"`
+}
+
 // ExecuteRundeckJob executes a job on Rundeck given a URL endpoint.
 // It returns an error if any.
-func ExecuteRundeckJob(URL string) error {
-	_, err := utils.MakeRundeckRequest(http.MethodPost, URL, nil)
+func ExecuteRundeckJob(URL string) (*JobExecResponse, error) {
+
+	r := &JobExecResponse{}
+
+	resp, err := utils.MakeRundeckRequest(http.MethodPost, URL, nil)
 	if err != nil {
-		return fmt.Errorf("cannot make Rundeck API call to execute job. Error: %v", err)
+		return nil, fmt.Errorf("cannot make Rundeck API call to execute job. Error: %v", err)
 	}
 
-	return nil
+	err = json.NewDecoder(resp.Body).Decode(r)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode response. Error: %v", err)
+	}
+
+	return r, nil
 }


### PR DESCRIPTION
This PR adds the functionality with tests, to acknowledge a single event after Rundeck executes the job and leaves a message on Zabbix.

Running the following, returns the message in the screenshot below.
```
go run main.go run job --project=zabideck --trigger="[RD] etc passwd has been changed on {HOST.NAME}" --event="49"
```
<img width="1577" alt="Screenshot 2019-04-26 at 11 31 35 PM" src="https://user-images.githubusercontent.com/10073270/56837660-7f72b200-687b-11e9-898c-324c09bdd31e.png">

All tests pass with `make test`

There is also a little refactor on other files. 

Fixes #8 