### PR TITLE
Use bash shell for build commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,11 @@ test:
 	go test ./...
 
 build-linux:
-	pushd cli/ && \
+	/bin/bash -c "pushd cli/ && \
 	CGO_ENABLED=0 GOOS=linux go build -o ../rundeck-zabbix  && \
-	popd
+	popd"
 
 build:
-	pushd cli/ && \
+	/bin/bash -c "pushd cli/ && \
 	go build -o ../rundeck-zabbix  && \
-	popd
+	popd"


### PR DESCRIPTION
This PR fixes the build command error ` pushd: not found` in Ubuntu by specifying the bash shell on the Makefile for the commands to be run in it.
